### PR TITLE
Fixed a typo and replaced info tag with one with an emoji

### DIFF
--- a/ssh_ntfy_pam_install.sh
+++ b/ssh_ntfy_pam_install.sh
@@ -55,14 +55,14 @@ case "\${PAM_TYPE}" in
     curl \\
       -H "prio: high" \\
       -H "tags: warning" \\
-      -d "SSH login: \${PAM_USER} \\
+      -d "SSH login: \${PAM_USER}" \\
       "${NTFY_TOPIC_URL}"
     ;;
   close_session)
     curl \\
       -H "prio: low" \\
-      -H "tags: info" \\
-      -d "SSH logout: \${PAM_USER} \\
+      -H "tags: information_source" \\
+      -d "SSH logout: \${PAM_USER}" \\
       "${NTFY_TOPIC_URL}"
     ;;
 esac


### PR DESCRIPTION
I fixed a typo at the -d option to the curl command (missing closing double quotes). Then, I replaced the "info" tag (when logging out) with "information_source", which has an associated emoji (see https://docs.ntfy.sh/emojis/)